### PR TITLE
Add some initial structure to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the temporary home for standards and guidance relating to software devel
 
 ## Contents
 
-TBC!
+- [Standards](/standards)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is the temporary home for standards and guidance relating to software devel
 ## Contents
 
 - [Guides](/guides)
+- [Processes](/processes)
 - [Standards](/standards)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is the temporary home for standards and guidance relating to software devel
 
 ## Contents
 
+- [Guides](/guides)
 - [Standards](/standards)
 
 ## About

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,7 @@
+# Guides
+
+This folder contains various guides to help those working in software development, both generally and in support our standards.
+
+## Contents
+
+TBC!

--- a/processes/README.md
+++ b/processes/README.md
@@ -1,0 +1,7 @@
+# Guides
+
+This folder contains documents which cover any processes related to software development. New starters or those not familiar with our processes may find them useful.
+
+## Contents
+
+TBC!

--- a/processes/README.md
+++ b/processes/README.md
@@ -1,4 +1,4 @@
-# Guides
+# Processes
 
 This folder contains documents which cover any processes related to software development. New starters or those not familiar with our processes may find them useful.
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,0 +1,7 @@
+# Standards
+
+This folder contains all current standards for software development.
+
+## Contents
+
+TBC!


### PR DESCRIPTION
The project is at its initial stages and we have been getting a brilliant flurry of PR's contributing various guides, standards and documents.

However they are all adding artefacts that just go into the root or the project. That's fine whilst we only have a handful, but as the project grows this is likely to become a burden. If nothing else we want the project's root README to be front and centre when someone navigates to https://github.com/DEFRA/software-development-standards, but the more files that exist at the root, the further down the page it'll be pushed.

I also think having some initial structure will help those looking to contribute because it will give them an indication of where their idea best fits in the project.

So this change adds some initial folders, each with their own README to indicate their purpose/content.

If this is accepted I'm more than happy to rebase and refactor all existing PR's to fit the structure, so please don't let be a concern 😄
