### PR TITLE
Add more detail about the PR process inc. approval

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,13 @@ If in doubt speak to [Alan Cruikshanks](https://github.com/cruikshanks) or [Ben 
 
 Create a branch with a brief but descriptive name e.g. `add-more-details-for-contributors`.
 
-Start committing your changes and **push** straight away rather than when finished.
+Start committing your changes and **push** straight away rather than when finished. We don't want your work to get lost!
 
 When you are ready for feedback create the pull request and announce your PR in our [slack channel](https://defra-digital.slack.com/messages/development/) in **Slack**.
+
+Also assign yourself to the PR so folks know who created it, and request a review from [DEFRA/sds-group](https://github.com/orgs/DEFRA/teams/sds-group).
+
+Consider also assigning a label to the PR. These can help potential reviewers quickly see the nature of the it.
 
 ## Getting feedback
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,15 @@ Create a branch with a brief but descriptive name e.g. `add-more-details-for-con
 
 Start committing your changes and **push** straight away rather than when finished. We don't want your work to get lost!
 
-When you are ready for feedback create the pull request and announce your PR in our [slack channel](https://defra-digital.slack.com/messages/development/) in **Slack**.
+When you are ready for feedback create the pull request. Take the time to give it a meaningful title and detailed description as this will help those reviewing it understand what you've done.
 
-Also assign yourself to the PR so folks know who created it, and request a review from [DEFRA/sds-group](https://github.com/orgs/DEFRA/teams/sds-group).
+> Pro tip! If you create the PR straight after your first commit, GitHub will automatically populate the title and description for the new PR from the commit message.
 
-Consider also assigning a label to the PR. These can help potential reviewers quickly see the nature of the it.
+Also assign yourself to the PR so folks know who created it and consider adding a label to the PR. These can help potential reviewers quickly see the nature of the it.
+
+When you are ready request a review from [DEFRA/sds-group](https://github.com/orgs/DEFRA/teams/sds-group).
+
+Finally announce your PR in our [slack channel](https://defra-digital.slack.com/messages/development/) in **Slack** to make sure no one can say they didn't know about it 😀.
 
 ## Getting feedback
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ It will formally be approved however by the Head of Standards, or in their absen
 
 ## Finishing up
 
-When your contribution has been accepted, you can go ahead and merge it using the GitHub UI for the pull request. If you have multiple commits on your branch it will squash them, and ask you to confirm what the final single commit message should be.
+When your contribution has been approved, you can go ahead and merge it using the GitHub UI for the pull request.
+
+> **IMPORTANT** If you have multiple commits on your branch it will squash them, and ask you to confirm what the final single commit message should be. Rewrite the message so it reflects the final change you've made (feedback may have changed your original intent) and why.
 
 With that done sit back, have a 🍹, and ponder your next contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Also assign yourself to the PR so folks know who created it and consider adding 
 
 When you are ready request a review from [DEFRA/sds-group](https://github.com/orgs/DEFRA/teams/sds-group).
 
-Finally announce your PR in our [slack channel](https://defra-digital.slack.com/messages/development/) in **Slack** to make sure no one can say they didn't know about it 😀.
+Finally announce your PR in our [slack channel](https://defra-digital.slack.com/messages/development-standards/) in **Slack** to make sure no one can say they didn't know about it 😀.
 
 ## Getting feedback
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ Feedback will be provided within the PR. Decisions will be documented and reason
 
 We want to encourage all to contribute and suggest ways we can improve. Anyone providing feedback should be positive and professional with any comments made about your contribution, but let us know if you feel we failed.
 
+## Approval
+
+Those that review your contribution when happy with it will leave a commit indicating so e.g. 👍, 🚢, LGTM.
+
+It will formally be approved however by the Head of Standards, or in their absence one of the Principal Developers. This will be done [via the GitHub UI](https://help.github.com/en/articles/approving-a-pull-request-with-required-reviews).
+
 ## Finishing up
 
 When your contribution has been accepted, you can go ahead and merge it using the GitHub UI for the pull request. If you have multiple commits on your branch it will squash them, and ask you to confirm what the final single commit message should be.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ We want to encourage all to contribute and suggest ways we can improve. Anyone p
 
 ## Approval
 
-Those that review your contribution when happy with it will leave a commit indicating so e.g. 👍, 🚢, LGTM.
+Those that review your contribution when happy with it will leave a comment indicating so e.g. 👍, 🚢, LGTM.
 
 It will formally be approved however by the Head of Standards, or in their absence one of the Principal Developers. This will be done [via the GitHub UI](https://help.github.com/en/articles/approving-a-pull-request-with-required-reviews).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ It is heavily inspired by the work of [ThoughtBot](https://github.com/thoughtbot
 
 ## Contributing to this project
 
-Please read the [contribution guidelines](/CONTRIBUTING.md) before submitting a pull request.
+We encourage everyone to contribute to these standards!
+
+We only ask that contributions are made using pull requests, where they can then be discussed and approved by the [DEFRA/sds-group](https://github.com/orgs/DEFRA/teams/sds-group).
+
+Please read the [contribution guidelines](/CONTRIBUTING.md) first for more details.
 
 ## License
 


### PR DESCRIPTION
We have a number of PR's being submitted (awesome 🙌) but what we don't actually have is any clarity about

- how exactly to setup the PR
- how the PR will get approved

This change intends to resolve this by adding more detail to `CONTRIBUTING.md` to cover these omissions.
