### PR TITLE
Fix links to ruby coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the temporary home for standards and guidance relating to software devel
 - [Processes](/processes)
 - [Standards](/standards)
   - [Common coding standards](/standards/common_coding_standards.md)
-  - [Ruby coding standards](/standards/ruby-coding-standards.md)
+  - [Ruby coding standards](/standards/ruby_coding_standards.md)
   - [Version control standards](/standards/version_control_standards.md)
 
 ## About

--- a/standards/README.md
+++ b/standards/README.md
@@ -5,5 +5,5 @@ This folder contains all current standards for software development.
 ## Contents
 
 - [Common coding standards](common_coding_standards.md)
-- [Ruby coding standards](ruby-coding-standards.md)
+- [Ruby coding standards](ruby_coding_standards.md)
 - [Version control standards](version_control_standards.md)


### PR DESCRIPTION
When we renamed the ruby coding standard file to use snake case we forgot to update the links to it in other documents. This change resolves the issue.