### PR TITLE
Add standard for READMEs

### DIFF
--- a/standards/readme_standards.md
+++ b/standards/readme_standards.md
@@ -12,7 +12,7 @@ The README should include the following (if they apply):
 - **How to run in development** – how to locally run the application in development mode after setup
 - **How to run tests** – how to run the test suite, broken into different categories if relevant (unit, integration, acceptance)
 - **Contributing to the project** - what to know before you submit your first pull request (this could also be in the form of a `CONTRIBUTING.md` file)
-- **License information** – what license the repo uses (in addition to your `LICENSE.md` file)
+- **Licence information** – what licence the repo uses (in addition to your `LICENSE` file)
 
 The file should be in Markdown format (.md).
 
@@ -39,7 +39,7 @@ If this documentation is too lengthy or complex, it doesn't have to be in the RE
 ```
 # name-of-repo
 
-The "Register your dinosaur" service allows customers to apply online for a dinosaur license.
+The "Register your dinosaur" service allows customers to apply online for a dinosaur licence.
 
 This application handles the backend dinosaur processing.
 
@@ -59,7 +59,7 @@ This application handles the backend dinosaur processing.
 
 Please read the [contribution guidelines](/CONTRIBUTING.md) before submitting a pull request.
 
-## License
+## Licence
 
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
@@ -67,9 +67,9 @@ THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE
 
 The following attribution statement MUST be cited in your products and applications when using this information.
 
->Contains public sector information licensed under the Open Government license v3
+>Contains public sector information licensed under the Open Government licence v3
 
-### About the license
+### About the licence
 
 The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 

--- a/standards/readme_standards.md
+++ b/standards/readme_standards.md
@@ -1,20 +1,26 @@
 # README standards
 
-A README file must exist in every repo in markdown format (.md). It must include the following if they apply:
+Every repo must have a README file in its root. The README is the starting point for anyone who wants to develop or test the repo. It provides an overview of what the repo is, and how to install, run and test its contents.
 
-- Description of product
-- Prerequisites
-- Development tools setup
-- Test tools setup
-- How to run in development
-- How to run tests
-- How to make changes to the code
+The README should include the following (if they apply):
+
+- **Description of the product** – what the service or product is, and what role this repo performs within it
+- **Prerequisites** – what you need to install or configure before you can set up the repo
+- **Setup process** - how to set up your local environment to work on the repo, including:
+  - development tools
+  - test tools
+- **How to run in development** – how to locally run the application in development mode after setup
+- **How to run tests** – how to run the test suite, broken into different categories if relevant (unit, integration, acceptance)
+- **Contributing to the project** - what to know before you submit your first pull request (this could also be in the form of a `CONTRIBUTING.md` file)
+- **License information** – what license the repo uses (in addition to your `LICENSE.md` file)
+
+The file should be in Markdown format (.md).
 
 ## Additional detail
 
-Depending on the complexity of the product, the following may be included in the README, or it may be more effective to capture in separate documentation/diagrams referenced by the README.
+You may also want to include:
 
-- How product fits into wider architecture
+- How the product fits into wider architecture
 - Internal product architecture
 - Data structure
 - API end points
@@ -25,3 +31,47 @@ Depending on the complexity of the product, the following may be included in the
 - Security
 - Complexity worth documenting
 - Pipelines
+
+If this documentation is too lengthy or complex, it doesn't have to be in the README. Just make sure your README tells users where to find these additional docs.
+
+## A basic README.md template
+
+```
+# name-of-repo
+
+The "Register your dinosaur" service allows customers to apply online for a dinosaur license.
+
+This application handles the backend dinosaur processing.
+
+## Prerequisites
+
+## Setup
+
+### Development
+
+### Test
+
+## Running in development
+
+## Running tests
+
+## Contributing to this project
+
+Please read the [contribution guidelines](/CONTRIBUTING.md) before submitting a pull request.
+
+## License
+
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+>Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.
+```

--- a/standards/readme_standards.md
+++ b/standards/readme_standards.md
@@ -1,0 +1,27 @@
+# README standards
+
+A README file must exist in every repo in markdown format (.md). It must include the following if they apply:
+
+- Description of product
+- Prerequisites
+- Development tools setup
+- Test tools setup
+- How to run in development
+- How to run tests
+- How to make changes to the code
+
+## Additional detail
+
+Depending on the complexity of the product, the following may be included in the README, or it may be more effective to capture in separate documentation/diagrams referenced by the README.
+
+- How product fits into wider architecture
+- Internal product architecture
+- Data structure
+- API end points
+- Monitoring
+- Error handling
+- Audit
+- User access
+- Security
+- Complexity worth documenting
+- Pipelines


### PR DESCRIPTION
This PR adds a standard for READMEs in project repos.

Following on from our group webex on 25 November, it is based off of the future farming docs (https://github.com/DEFRA/ffc-development-guide/blob/master/docs/documentation-standards.md) but with some modifications.

The intent is that we will iterate to include more documentation about documentation, but this is a starting point.