### PR TITLE
Add guidance for auto formatting in TOAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the temporary home for standards and guidance relating to software devel
 - [Guides](/guides)
   - [Choosing packages](/guides/choosing_packages.md)
   - [Developer workflows](/guides/developer_workflows.md)
+  - [PL/SQL auto-format with TOAD](/guides/plsql_auto_format_toad.md)
   - [SQL Prompt](/guides/version_control_guidance.md)
   - [Version control guidance](/guides/version_control_guidance.md)
 - [Principles](/principles)

--- a/guides/README.md
+++ b/guides/README.md
@@ -6,5 +6,6 @@ This folder contains various guides to help those working in software developmen
 
 - [Choosing packages](choosing_packages.md)
 - [Developer workflows](developer_workflows.md)
+- [PL/SQL auto-format with TOAD](plsql_auto_format_toad.md)
 - [SQL Prompt](sql_prompt.md)
 - [Version control guidance](version_control_guidance.md)

--- a/guides/defra_plsql_toad_fmt.opt
+++ b/guides/defra_plsql_toad_fmt.opt
@@ -1,0 +1,5 @@
+
+[Qp5FormatterOptions]
+Version=145
+CommaStyle=2
+Tagline=0

--- a/guides/plsql_auto_format_toad.md
+++ b/guides/plsql_auto_format_toad.md
@@ -6,7 +6,7 @@
 
 Some teams in Defra have licenses for Toad, and use it when working with our Oracle databases.
 
-We have a [standard for PL/SQL](/standards/plsql_standards.md) which can be applied automatically using the auto-format tool in Toad.
+We have a [standard for PL/SQL](/standards/plsql_coding_standards.md) which can be applied automatically using the auto-format tool in Toad.
 
 ## The format file
 

--- a/guides/plsql_auto_format_toad.md
+++ b/guides/plsql_auto_format_toad.md
@@ -1,0 +1,23 @@
+# PL/SQL Auto-format with TOAD
+
+[Toad](https://en.wikipedia.org/wiki/Toad_(software)) is a
+
+> [..] database management toolset from Quest Software that database developers, database administrators, and data analysts use to manage both relational and non-relational databases using SQL.
+
+Some teams in Defra have licenses for Toad, and use it when working with our Oracle databases.
+
+We have a [standard for PL/SQL](/standards/plsql_standards.md) which can be applied automatically using the auto-format tool in Toad.
+
+## The format file
+
+In these guides is an auto-format `.opt` file that can be used called [defra_plsql_toad_fmt.opt](defra_plsql_toad_fmt.opt).
+
+## Importing the file
+
+In Toad, open an Editor window. Right click on the editor pane and select `Formatting Tools > Formatting Options`.
+
+Select the file open icon at the top left of the screen ("Load options from file" is the tool tip) and then browse to where you have located a copy of the file. Select the file then hit "Apply". Then hit "OK" to close the formatter options window.
+
+## Applying the format
+
+To apply the formatter options to any SQL or PL/SQL code open the code in the Editor Window, right click and then select `Formatting Tools > Format`.


### PR DESCRIPTION
This stems from an agreed refactoring of PR #8 (PL/SQL coding standards). It was highlighted in that PR some of the content would be more appropriate as guidance, rather than being a standard we must all follow.

So it was suggested to extract and move it into the `/guidance` section of the project.

SO the content of this PR comes from @nigejohnson and questions and comments should be directed to him 😁

Anything regards structure and how the changes were made, feel free to fire at me @Cruikshanks 😰