### PR TITLE
Separated out browser coding guidance from the javascript standard

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -4,6 +4,7 @@ This folder contains various guides to help those working in software developmen
 
 ## Contents
 
+- [Browser code](browser_code.md)
 - [Choosing packages](choosing_packages.md)
 - [Developer workflows](developer_workflows.md)
 - [SQL Prompt](sql_prompt.md)

--- a/guides/browser_code.md
+++ b/guides/browser_code.md
@@ -1,0 +1,19 @@
+## Browser code
+
+This guidance provides some useful pointers when developing code for the browser.
+
+### General
+* Test your code for compatibility with your target browsers using a tool such as
+  [Browserstack](https://www.browserstack.com).
+* Don't pollute the global state. Take steps such as using a build tool to combine related files or,
+  at a minimum, [write to window.somenamespace.x rather than window.x](https://www.zendesk.com/blog/keep-javascript-libraries-from-colliding/).
+* Think about how you will collect information about errors on the client and consider the use of a tool such as
+  [airbrake-js](https://github.com/airbrake/airbrake-js).
+
+### Security
+* Understand and mitigate the risks of XSS and XSI attacks on your service.
+  See the OWASP [cheat sheets](https://github.com/OWASP/CheatSheetSeries) for an introduction to these issues.
+* Protect against XSS attacks by ensuring that you encode inputs to your service on both the client and server.
+  You should also perform additional validation on incoming parameters where necessary.
+  Depending on the library you are using you may need to JS encode and HTML encode to do this.
+* Validate inputs on the [client and the server](https://stackoverflow.com/questions/15855770/why-do-we-need-both-client-side-and-server-side-validation#15855799).


### PR DESCRIPTION
Following discussion on the Javascript standard, that has now been distilled down to just using Standard JS, so I've moved this guidance into a separate branch.

This PR is to discuss whether we are still happy to have this information in just as guidance.