### PR TITLE
Add example effective dates to a standard

### DIFF
--- a/standards/java_coding_standards.md
+++ b/standards/java_coding_standards.md
@@ -263,3 +263,9 @@ Other javadocs tags can be used as required.
 - Both multi-line (`\* */`) and single line (`//`) comments may be used
 
 - Comments within the method body should, wherever possible, be restricted to single line comments
+
+## Standard applied
+
+This standard was first agreed on 10 Feb 2020.
+
+This standard was last updated on 10 Feb 2020.

--- a/standards/java_coding_standards.md
+++ b/standards/java_coding_standards.md
@@ -264,8 +264,6 @@ Other javadocs tags can be used as required.
 
 - Comments within the method body should, wherever possible, be restricted to single line comments
 
-## Standard applied
+## Status
 
-This standard was first agreed on 10 Feb 2020.
-
-This standard was last updated on 10 Feb 2020.
+This standard was formally adopted on 20 Feb 2021.


### PR DESCRIPTION
Some of the PR's have include discussions about ensuring teams are not penalised because they are having to work with code bases that do not follow whatever is the current latest standard as defined here.

We have discussed manually versioning our standards. Concensus however was as we are using source control, manually applying a version seems an unnecessary burden. Another solution has been to use dates. This solution also fits in with one of our current principles for standards

> ...all standards must define the period of time that they are effective and how they have changed over time

The problem is we don't as yet have an actual example of how to go about this. Hence this proposed change to the Java coding standard, to demonstrate (and collaborate) on an approach that can then be retroactively applied to our existing standards, and used for any new ones in the future.