### PR TITLE
Style, writing and formatting guide for standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ If in doubt speak to [Alan Cruikshanks](https://github.com/cruikshanks) or [Ben 
 
 ## Getting started
 
+Read the [style guide for standards](/guides/style_guide_for_standards.md).
+
 Create a branch with a brief but descriptive name e.g. `add-more-details-for-contributors`.
 
 Start committing your changes and **push** straight away rather than when finished. We don't want your work to get lost!

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is the temporary home for standards and guidance relating to software devel
   - [Java auto-format with Eclipse](/guides/java_auto_format_eclipse.md)
   - [PL/SQL auto-format with TOAD](/guides/plsql_auto_format_toad.md)
   - [SQL Prompt](/guides/version_control_guidance.md)
+  - [Style guide for standards](/guides/style_guide_for_standards.md)
   - [Version control guidance](/guides/version_control_guidance.md)
 - [Principles](/principles)
   - [Coding principles](/principles/coding_principles.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -10,6 +10,7 @@ This folder contains various guides to help those working in software developmen
 - [Java auto-format with Eclipse](java_auto_format_eclipse.md)
 - [PL/SQL auto-format with TOAD](plsql_auto_format_toad.md)
 - [SQL Prompt](sql_prompt_tool.md)
+- [Style guide for standards](style_guide_for_standards.md)
 - [Version control guidance](version_control_guidance.md)
 
 ## General guidance

--- a/guides/style_guide_for_standards.md
+++ b/guides/style_guide_for_standards.md
@@ -1,0 +1,60 @@
+# Style guide for software development standards
+
+This guide tells you how to write and format standards and other documents for this repository.
+
+We want our standards to be:
+
+- clear
+- consistent
+- easy to read
+
+If a standard is easy to understand, it's also easier to follow it correctly.
+
+[Guidelines for writing for the web](https://www.bath.ac.uk/guides/writing-for-the-web/)
+
+## Be clear and focused
+
+A standard should set clear rules. A guide should give clear advice.
+
+Be concise. Focus on what is most important. Avoid woolly language and excessive detail.
+
+It should be straightforward to answer "Does this project meet the standard?" with a "yes" or "no". Basically, in developer terms, a standard should be easily testable.
+
+## Be easy to skim
+
+We'd love everyone to read every last word of these standards. But in reality, people often skim the content they read on the web.
+
+To make content easier to skim:
+
+- use short sentences and paragraphs
+- break up writing into multiple sections with clear subheadings
+- display information in bulleted lists
+- put the most important information first
+
+This helps users to quickly understand the main points of a standard. It also makes it easier to find the specific information they're looking for.
+
+## Use plain English
+
+Our guides and standards should use plain English whenever possible. What we write about can be complex, but the way we write about it doesn't have to be.
+
+We are writing for a specialist audience. But [even specialists want content to be easy to read](https://gds.blog.gov.uk/2014/02/17/guest-post-clarity-is-king-the-evidence-that-reveals-the-desperate-need-to-re-think-the-way-we-write/):
+
+> when given a choice, 80% of people preferred sentences written in clear English ... the more specialist their knowledge, the greater their preference for plain English
+
+It's fine to use technical terminology, but avoid corporate jargon.
+
+## Check your writing for clarity
+
+[Hemingway](http://www.hemingwayapp.com/) is an online tool that helps make writing easier to read.
+
+It makes suggestions for when to simplify vocabulary or split up sentences that are too long.
+
+You don't have to obey every suggestion from Hemingway, but it can be a useful guide.
+
+## Use Markdown for formatting
+
+There are a few variations of Markdown, so we use the standard GitHub syntax.
+
+[Read GitHub's formatting guidance](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax)
+
+Name each file using snake case (for example, `style_guide_for_standards.md`).


### PR DESCRIPTION
https://github.com/DEFRA/software-development-standards/issues/55

As discussed in the meeting today. This should cover the points we talked about, including Markdown and the concept of a standard being "easily testable".

This covers some basic formatting guidance, and some general writing advice for the tone and style of the guides. The goal is to make our standards easy to understand, and therefore easy to adopt.

I've also linked to some more extensive guidelines on writing for the web. These are written for a slightly different audience but I think the principles still apply. (Also, I wrote some of them back when I used to be a content person.)