### PR TITLE
Remove reference to IE11 in QA standards

### DIFF
--- a/docs/standards/quality_assurance_standards.md
+++ b/docs/standards/quality_assurance_standards.md
@@ -17,7 +17,7 @@ Default acceptance criteria for new stories:
 * Screens, behaviour and content match designs from the prototype or wireframe
 * Styles match the [design system](https://design-system.service.gov.uk/)
 * Accessible - meets [Web Content Accessibility Guidelines (WCAG) version 2.1](https://www.w3.org/WAI/standards-guidelines/wcag/glance/) at levels A and AA
-* Works across [all supported browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) including IE11 and mobile
+* Works across [all supported browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) including mobile
 * Server-side [error validation](https://design-system.service.gov.uk/components/error-message/) exists for all fields
 * No obvious performance issues (most transactions under 1 second, avoid transactions over 10 seconds)
 * No existing functionality has regressed


### PR DESCRIPTION
This commit removes a reference to the need to support IE11 in the quality assurance and testing standards now this has dropped out of the browser support matrix. The browser support matrix is already correctly linked so this removes a potential source of confusion for readers.