### PR TITLE
Extend GitHub archive grace period

### DIFF
--- a/docs/processes/github_access.md
+++ b/docs/processes/github_access.md
@@ -72,9 +72,9 @@ We typically archive repositories rather than deleting them, as the code they co
 
 Repositories without an administrator will be archived by the organisation owners.
 
-Repositories that have been inactive for 24 months or more will be archived by the organisation owners.
+Repositories that have been inactive for 36 months or more will be archived by the organisation owners.
 
-If an archived repository has an associated SonarQube Cloud project then that will be deleted by the organisation owners. Projects will also be deleted if they haven't been analysed for 24 months or more.
+If an archived repository has an associated SonarQube Cloud project then that will be deleted by the organisation owners. Projects will also be deleted if they haven't been analysed for 36 months or more.
 
 ## Access removal
 


### PR DESCRIPTION
Several repos that are ~3 years old still represent known live services.

Proposing to extend the archive grace period from 24 months to 36.